### PR TITLE
Issue 4779 - Application name wraps when displayed in app drawer

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/launcher_name"
         android:theme="@style/AppTheme" >
         <activity
             android:name="org.adblockplus.sbrowser.contentblocker.MainPreferences"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">Adblock Plus</string>
+    <string name="app_name">Adblock Plus for Samsung Internet</string>
+    <string name="launcher_name">Adblock Plus</string>
     <string name="automatic_updates">Configure automatic updates</string>
     <string name="manage_subscriptions">Configure your filter lists</string>
     <string name="manage_subscriptions_summary">Change ad blocking languages</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">Adblock Plus for Samsung Internet</string>
+    <string name="app_name">Adblock Plus</string>
     <string name="automatic_updates">Configure automatic updates</string>
     <string name="manage_subscriptions">Configure your filter lists</string>
     <string name="manage_subscriptions_summary">Change ad blocking languages</string>


### PR DESCRIPTION
https://issues.adblockplus.org/ticket/4779